### PR TITLE
Make _grid mixin better and add support for IE7

### DIFF
--- a/lib/grid/grid-base.styl
+++ b/lib/grid/grid-base.styl
@@ -77,25 +77,31 @@ grid-widths($namespace, $columns)
 
 
 //
+// IE7 SUPPORT
+// Enables support for IE7 using expressions
+
+grid-widths-ie7($namespace, $columns)
+  _grid($namespace, $columns, 'width', true)
+
+width-ie7($width)
+  unquote('expression((this.parentNode.clientWidth * '+($width / 100)+' - parseInt(this.currentStyle["paddingLeft"]) - parseInt(this.currentStyle["paddingRight"]) - (parseInt(this.currentStyle["borderLeftWidth"]) || 0) - (parseInt(this.currentStyle["borderRightWidth"]) || 0) ) + "px")')
+
+
+//
 // INTERNAL MIXINS
 // These mixins should not be called directly,
 // instead are used as helpers within other mixins
 //
 
-_grid($namespace, $columns, $property)
+_grid($namespace, $columns, $property, ie7=false)
   for $column, $i in $columns
     $grid = $grid--fraction-names[$column - 1]
-    if ($column - 1 > 0)
-      // Loop trough col size names
-      for $size, $j in $grid--count-names
-        // Check if we need this size
-        if $j < ($column - 1)
-          $plural = $j is 0 ? '' : 's'
-          .{$namespace}{$size}-{$grid[0]}{$plural}
-            {$property} ($j+1) * (100% / $column)
-    else
-      .{$namespace}{$grid--count-names[0]}-{$grid[0]}
-        {$property} 100%
+    $numCols = $column is 1 ? 1 : $column - 1
+    for $j in (1..$numCols)
+      $plural = $j is 1 ? '' : 's'
+      $width = $j * (100 / $column)
+      .{$namespace}{$grid--count-names[$j - 1]}-{$grid}{$plural}
+        {$property} !ie7 ? ($width)% : width-ie7($width)
 
 _grid-gutter--item($g)
   if unit($g) == '%'

--- a/test/tests/grid.styl
+++ b/test/tests/grid.styl
@@ -262,6 +262,19 @@ grid-widths('desktop-', 1)
   width: 100%;
 }
 
+// @it output grid widths for IE7
+
+grid-widths-ie7('', 1 2)
+
+// @expect
+.one-whole {
+  width: expression((this.parentNode.clientWidth * 1 - parseInt(this.currentStyle["paddingLeft"]) - parseInt(this.currentStyle["paddingRight"]) - (parseInt(this.currentStyle["borderLeftWidth"]) || 0) - (parseInt(this.currentStyle["borderRightWidth"]) || 0) ) + "px")
+}
+
+.one-half {
+  width: expression((this.parentNode.clientWidth * 0.5 - parseInt(this.currentStyle["paddingLeft"]) - parseInt(this.currentStyle["paddingRight"]) - (parseInt(this.currentStyle["borderLeftWidth"]) || 0) - (parseInt(this.currentStyle["borderRightWidth"]) || 0) ) + "px")
+}
+
 // @it output custom names for grid widths to allow for i18n
 $grid--count-names = uno dos tres
 $grid--fraction-names = primero segundo tercero


### PR DESCRIPTION
Refactored the _grid a bit by removing some stupid if statements and changing the loop to only loop trough the columns it needs instead of every name in the array.

Added support for IE7 in a grid-widths-ie7 mixin that calls the _grid with a 4 parameter set to true.

Unit tests for ie7 stuff added.
