### PR TITLE
Update `grid-gutter-modifier` mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,14 @@ This will set up push classes based on the `$columns` you include.
 
 ### `grid-gutter-modifier($namespace, $gutter)`
 
-This will set up the gutter modifier `.grid--{$namespace}` class and `.grid__item` children elements which modify the gutter width.
+This will set up the gutter modifier `.grid--{$namespace}` class and `.grid__item` child selector which modify the gutter width.
+Providing a `$namespace` is optional which allows the mixin to be used to change the base grid gutter at different breakpoints.
 
 #### Examples
-
-* `grid-gutter-modifier('em', 1em)` will set up a `.grid--{$namespace}` class that will provided 1em gutter between each `.grid__item`.
-* `grid-gutter-modifier('percent', 10%)` will set up a `.grid--{$namespace}` class that will provided 10% gutter between each `.grid__item`.
-* `grid-gutter-modifier('pixel', 20px)` will set up a `.grid--{$namespace}` class that will provided 20px gutter between each `.grid__item`.
+* `grid-gutter-modifier('', 10px)` will set up a `.grid` class that will provide a 10px gutter between each `.grid__item`.
+* `grid-gutter-modifier('em', 1em)` will set up a `.grid--{$namespace}` class that will provide a 1em gutter between each `.grid__item`.
+* `grid-gutter-modifier('percent', 10%)` will set up a `.grid--{$namespace}` class that will provide a 10% gutter between each `.grid__item`.
+* `grid-gutter-modifier('pixel', 20px)` will set up a `.grid--{$namespace}` class that will provide a 20px gutter between each `.grid__item`.
 
 ---
 

--- a/lib/responsive-grid/grid-base.styl
+++ b/lib/responsive-grid/grid-base.styl
@@ -50,12 +50,10 @@ grid-base()
 //
 
 grid-gutter-modifier($namespace = '', $grid-modifier--gutter)
-  if $namespace == ''
-    $namespace = 'grid'
-  else
-    $namespace = 'grid--' + $namespace
+  if $namespace != ''
+    $namespace = '--' + $namespace
 
-  .{$namespace}
+  .grid{$namespace}
     margin-left -($grid-modifier--gutter)
 
     & > .grid__item

--- a/lib/responsive-grid/grid-base.styl
+++ b/lib/responsive-grid/grid-base.styl
@@ -49,8 +49,13 @@ grid-base()
 // Custom gutter widths
 //
 
-grid-gutter-modifier($namespace, $grid-modifier--gutter)
-  .grid--{$namespace}
+grid-gutter-modifier($namespace = '', $grid-modifier--gutter)
+  if $namespace == ''
+    $namespace = 'grid'
+  else
+    $namespace = 'grid--' + $namespace
+
+  .{$namespace}
     margin-left -($grid-modifier--gutter)
 
     & > .grid__item

--- a/test/tests/grid.styl
+++ b/test/tests/grid.styl
@@ -117,6 +117,17 @@ grid-gutter-modifier('bar', 10%)
   padding-left: 9.09090909090909%;
 }
 
+// @it output a grid gutter modifier without specifing a namespace
+grid-gutter-modifier('', 10px)
+
+// @expect
+.grid {
+  margin-left: -10px;
+}
+.grid > .grid__item {
+  padding-left: 10px;
+}
+
 // @describe grid-reverse()
 
 // @it output styles to visually reverse grid item order


### PR DESCRIPTION
Providing $namespace is now optional for the `grid-gutter-modifier` mixin. This will allow the mixin to be used to change the normal grid gutter at different breakpoints.
Updated tests.